### PR TITLE
module_adapter: change the buffer size of waves_codec

### DIFF
--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -330,8 +330,8 @@ static int waves_effect_init(struct comp_dev *dev)
 	waves_codec->o_format = waves_codec->i_format;
 
 	waves_codec->sample_size_in_bytes = sample_bytes;
-	waves_codec->buffer_samples = (src_fmt->rate * 2) / 1000; /* 2 ms io buffers */
-	waves_codec->buffer_bytes = waves_codec->buffer_samples * src_fmt->channels *
+	waves_codec->buffer_bytes = component->period_bytes;
+	waves_codec->buffer_samples = waves_codec->buffer_bytes / src_fmt->channels /
 		waves_codec->sample_size_in_bytes;
 
 	// trace allows printing only up-to 4 words at a time


### PR DESCRIPTION
Change the buffer size of waves_codec from 2ms to SCHEDULE_PERIOD

commit e9442e04c67e ("module_adpater: change the buffer size
of waves_codec")

backport anf fix conflict by modifying to component->period_bytes

Signed-off-by: CY Kuei <cyk@waves.com>
Signed-off-by: Mac Chiang <mac.chiang@intel.com>
Change-Id: I427d59c6dd673cfaa3bfa2511485db360d397721