### PR TITLE
[EXPERINMENT] topology: 98373 pop noise

### DIFF
--- a/tools/topology/topology1/sof-eq-iir-dts-codec-smart-amplifier.m4
+++ b/tools/topology/topology1/sof-eq-iir-dts-codec-smart-amplifier.m4
@@ -221,10 +221,10 @@ DAI_CONFIG(ALH, eval(SMART_ALH_INDEX + 1), eval(SMART_BE_ID + 1), SMART_ALH_CAPT
 `
 #SSP SSP_INDEX (ID: SMART_BE_ID)
 DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
-	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
-		      SSP_CLOCK(bclk, 12288000, codec_slave),
+	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 6144000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
-		      SSP_TDM(8, 32, 15, 255),
+		      SSP_TDM(4, 32, 15, 15),
 		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 32, 0, SMART_SSP_QUIRK)))
 ')
 

--- a/tools/topology/topology1/sof-smart-amplifier.m4
+++ b/tools/topology/topology1/sof-smart-amplifier.m4
@@ -237,10 +237,10 @@ DAI_CONFIG(ALH, eval(SMART_ALH_INDEX + 1), eval(SMART_BE_ID + 1), SMART_ALH_CAPT
 `
 #SSP SSP_INDEX (ID: SMART_BE_ID)
 DAI_CONFIG(SSP, SMART_SSP_INDEX, SMART_BE_ID, SMART_SSP_NAME,
-	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, SSP_MCLK, codec_mclk_in),
-		      SSP_CLOCK(bclk, 12288000, codec_slave),
+	SSP_CONFIG(DSP_B, SSP_CLOCK(mclk, 19200000, codec_mclk_in),
+		      SSP_CLOCK(bclk, 6144000, codec_slave),
 		      SSP_CLOCK(fsync, 48000, codec_slave),
-		      SSP_TDM(8, 32, 15, 255),
+		      SSP_TDM(4, 32, 15, 15),
 		      SSP_CONFIG_DATA(SSP, SMART_SSP_INDEX, 32, 0, SMART_SSP_QUIRK)))
 ')
 


### PR DESCRIPTION
when speaker start playing, there is a pop at beginning. Also there were two pops shen speaker stop playing.

test:
aplay -D hw:0,0 -f dat 1k.wav
play -n synth sine 1000
cras_test_client --playback_file 1k.wav
switching speaker from/to headphone repeatedly via Chrome audio UI menu.

change:
MCLK:19.2MHz
BCLK: 6.144MHz
TDM: 4 slots, tx slots: 0xF, rx slots: 0xF.

the pop is goine.