### PR TITLE
topology: sof-glk/jsl-da7219: enable bclk control early start

### DIFF
--- a/tools/topology/topology1/sof-glk-da7219-kwd.m4
+++ b/tools/topology/topology1/sof-glk-da7219-kwd.m4
@@ -241,7 +241,7 @@ DAI_CONFIG(SSP, SSP_INDEX, 1, SSP_NAME,
                 SSP_CLOCK(bclk, SSP_BCLK, codec_slave),
                 SSP_CLOCK(fsync, SSP_FSYNC, codec_slave),
                 SSP_TDM(2, SSP_BITS_WIDTH, 3, 3),
-                SSP_CONFIG_DATA(SSP, SSP_INDEX, SSP_VALID_BITS, MCLK_ID)))
+                SSP_CONFIG_DATA(SSP, SSP_INDEX, SSP_VALID_BITS, MCLK_ID, 0, 0, SSP_CC_BCLK_ES)))
 
 # dmic01 (ID: 2)
 DAI_CONFIG(DMIC, 0, 2, dmic01,

--- a/tools/topology/topology1/sof-glk-da7219.m4
+++ b/tools/topology/topology1/sof-glk-da7219.m4
@@ -193,7 +193,7 @@ DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 		SSP_CLOCK(bclk, 1920000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 20, 3, 3),
-		SSP_CONFIG_DATA(SSP, 2, 16, 1)))
+		SSP_CONFIG_DATA(SSP, 2, 16, 1, 0, 0, SSP_CC_BCLK_ES)))
 ', HEADPHONE, `cs42l42', `
 #SSP 2 (ID: 1) with 19.2 MHz mclk with MCLK_ID 1 (unused), 2.4 MHz bclk, no quirk, 10 ms BCLK delay
 DAI_CONFIG(SSP, 2, 1, SSP2-Codec,

--- a/tools/topology/topology1/sof-jsl-da7219.m4
+++ b/tools/topology/topology1/sof-jsl-da7219.m4
@@ -173,7 +173,7 @@ DAI_CONFIG(SSP, 0, 1, SSP0-Codec,
 		SSP_CLOCK(bclk, 2400000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 25, 3, 3),
-		SSP_CONFIG_DATA(SSP, 0, 16)))
+		SSP_CONFIG_DATA(SSP, 0, 16, 0, 0, 0, SSP_CC_BCLK_ES)))
 
 # 3 HDMI/DP outputs (ID: 3,4,5)
 DAI_CONFIG(HDA, 0, 3, iDisp1,


### PR DESCRIPTION
provide bclk clock early, so that da7219 SRM lock success without retries cosuming time.

Signed-off-by: Mac Chiang <mac.chiang@intel.com>