### PR TITLE
topology: sof-glk-da7219: enable bclk control early start

### DIFF
--- a/tools/topology/sof-glk-da7219-kwd.m4
+++ b/tools/topology/sof-glk-da7219-kwd.m4
@@ -196,7 +196,7 @@ DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 		SSP_CLOCK(bclk, 1920000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 20, 3, 3),
-		SSP_CONFIG_DATA(SSP, 2, 16, 1)))
+		SSP_CONFIG_DATA(SSP, 2, 16, 1, 0, SSP_CC_BCLK_ES)))
 
 # dmic01 (ID: 2)
 DAI_CONFIG(DMIC, 0, 2, dmic01,

--- a/tools/topology/sof-glk-da7219.m4
+++ b/tools/topology/sof-glk-da7219.m4
@@ -171,7 +171,7 @@ DAI_CONFIG(SSP, 2, 1, SSP2-Codec,
 		SSP_CLOCK(bclk, 1920000, codec_slave),
 		SSP_CLOCK(fsync, 48000, codec_slave),
 		SSP_TDM(2, 20, 3, 3),
-		SSP_CONFIG_DATA(SSP, 2, 16, 1)))
+		SSP_CONFIG_DATA(SSP, 2, 16, 1, 0, SSP_CC_BCLK_ES)))
 ', HEADPHONE, `cs42l42', `
 #SSP 2 (ID: 1) with 19.2 MHz mclk with MCLK_ID 1 (unused), 2.4 MHz bclk
 DAI_CONFIG(SSP, 2, 1, SSP2-Codec,


### PR DESCRIPTION
provide bclk clock early, so that da7219 SRM lock success without retries of cosuming time.

Signed-off-by: Mac Chiang <mac.chiang@intel.com>