### PR TITLE
codec_adapter: correct the way to get the scheduling period

### DIFF
--- a/src/audio/codec_adapter/codec/waves.c
+++ b/src/audio/codec_adapter/codec/waves.c
@@ -330,7 +330,10 @@ static int waves_effect_init(struct comp_dev *dev)
 	waves_codec->o_format = waves_codec->i_format;
 
 	waves_codec->sample_size_in_bytes = sample_bytes;
-	waves_codec->buffer_samples = (src_fmt->rate * 2) / 1000; /* 2 ms io buffers */
+	/* Prepare a buffer for 1 period worth of data
+	 * dev->pipeline->period stands for the scheduling period in us
+	 */
+	waves_codec->buffer_samples = src_fmt->rate * dev->pipeline->period / 1000000;
 	waves_codec->buffer_bytes = waves_codec->buffer_samples * src_fmt->channels *
 		waves_codec->sample_size_in_bytes;
 


### PR DESCRIPTION
To align the pipeline 48 frames buffers.
Scheduling period should be acquired from dev->pipeline->period

Signed-off-by: CY Kuei <cyk@waves.com>
Signed-off-by: Mac Chiang <mac.chiang@intel.com>
(backport from commit 285df36f1b435278cd230500385d4bd9f515c56f)