### PR TITLE
Tools: rimage: include DTS toml support

### DIFF
--- a/tools/rimage/config/ptl.toml.h
+++ b/tools/rimage/config/ptl.toml.h
@@ -122,6 +122,10 @@ index = __COUNTER__
 #include <audio/tdfb/tdfb.toml>
 #endif
 
+#if defined(CONFIG_DTS_CODEC) || defined(LLEXT_FORCE_ALL_MODULAR)
+#include <audio/codec/dts/dts.toml>
+#endif
+
 #if defined(CONFIG_COMP_RTNR) || defined(LLEXT_FORCE_ALL_MODULAR)
 #include <audio/rtnr/rtnr.toml>
 #endif


### PR DESCRIPTION
This change includes DTS component into firmware for PTL platform.